### PR TITLE
use options.urls instead of this.data.urls

### DIFF
--- a/tasks/fastly.js
+++ b/tasks/fastly.js
@@ -52,11 +52,11 @@ module.exports = function(grunt) {
       grunt.fail.fatal('If purging specific urls, a host must be provided.');
     }
 
-    if (typeof this.data.urls === 'undefined') {
-      this.data.urls = [];
+    if (typeof options.urls === 'undefined') {
+      options.urls = [];
     }
 
-    async.eachLimit(this.data.urls, options.concurrentPurges, function(uriPath, next) {
+    async.eachLimit(options.urls, options.concurrentPurges, function(uriPath, next) {
       var uri = url.format({host: options.host, pathname: uriPath}).substr(2);
 
       fastly.purge(options.host, uriPath, function(err) {


### PR DESCRIPTION
I was unable to purge using the `urls` array in the task config until I made this change. The grunt docs [discourage using `this.data`](http://gruntjs.com/api/inside-tasks#this.data) in favor of `this.options` anyway, so hopefully this should do the trick :)
