### PR TITLE
update fastly module to fix purging

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ grunt.initConfig({
       options: {
         host: 'example.com',
         urls: [
-          'path/to/asset1.jpg',
-          'path/to/asset2.jpg'
+          '/path/to/asset1.jpg',
+          '/path/to/asset2.jpg'
         ]
       }
     },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "fastly": "~0.1.2",
+    "fastly": "~1.2.1",
     "async": "~0.2.9"
   }
 }

--- a/tasks/fastly.js
+++ b/tasks/fastly.js
@@ -29,7 +29,7 @@ module.exports = function(grunt) {
       grunt.fail.fatal('Fastly api key is required.');
     }
 
-    fastly.authenticate(options.key);
+    fastly = fastly(options.key);
 
     // Purge all cache from a service
     if (options.purgeAll) {


### PR DESCRIPTION
Purging didn’t work because the `fastly` node module was hitting the wrong API URL. Thankfully this was fixed in a later version, so updating the dependency should fix the issue.