### PR TITLE
Adding support for Surrogate-Key purging.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,6 +37,12 @@ module.exports = function(grunt) {
           serviceId: 'service id'
         }
       },
+      purgeKey: {
+        options: {
+          purgeKey: 'surrogate-key',
+          serviceId: 'service id'
+        }
+      },
       purgeFiles: {
         options: {
           host: 'example.com'
@@ -77,6 +83,7 @@ module.exports = function(grunt) {
     }
 
     fastly.purgeAll = mocker('purgeAll');
+    fastly.purgeKey = mocker('purgeKey');
     fastly.purge = mocker('purge');
   });
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Default value: `false`
 
 Purge all cached files from a cache. If this value is true, a serice id must also be provided.
 
+#### options.purgeKey
+Type: `String`
+
+The key you wish to purge from a cache.
+
 #### options.serviceId
 Type: `String`
 
@@ -80,6 +85,25 @@ grunt.initConfig({
     production: {
       options: {
         purgeAll: true,
+        serviceId: 'production service id from Fastly'
+      }
+    }
+  },
+})
+```
+
+#### Purge Key
+In this example, all cached files associated with the key will be purged from the production service.
+
+```js
+grunt.initConfig({
+  fastly: {
+    options: {
+      key: 'your api key'
+    },
+    production: {
+      options: {
+        purgeKey: 'surrogate-key',
         serviceId: 'production service id from Fastly'
       }
     }

--- a/tasks/fastly.js
+++ b/tasks/fastly.js
@@ -47,6 +47,22 @@ module.exports = function(grunt) {
       return
     }
 
+    // Purge content matching key
+    if (options.purgeKey) {
+      if (typeof options.serviceId === 'undefined') {
+        grunt.fail.fatal('A serviceId must be provided when purging all cache.');
+      }
+
+      grunt.log.write('Purging Key "'+options.purgeKey+'" from "'+options.serviceId+'"...');
+      fastly.purgeKey(options.serviceId, options.purgeKey, function(err) {
+        if (err) grunt.log.error();
+        else grunt.log.ok();
+
+        done();
+      });
+      return
+    }
+
     // Purge only specific urls
     if (typeof options.host === 'undefined') {
       grunt.fail.fatal('If purging specific urls, a host must be provided.');


### PR DESCRIPTION
This pull adds support for [Surrogate-Key](https://www.fastly.com/blog/surrogate-keys-part-1) purging.

I left out the test as I couldn't get them to work. Checkout the errors [here](https://gist.github.com/lukebussey/b2bd3502774c4f1f7586).

Thanks!
